### PR TITLE
Rename '_' variables for Java 8+ compatibility.

### DIFF
--- a/src/main/java/org/docopt/Docopt.java
+++ b/src/main/java/org/docopt/Docopt.java
@@ -1,27 +1,14 @@
 package org.docopt;
 
-import static org.docopt.Python.bool;
-import static org.docopt.Python.in;
-import static org.docopt.Python.isUpper;
-import static org.docopt.Python.join;
-import static org.docopt.Python.list;
-import static org.docopt.Python.partition;
-import static org.docopt.Python.set;
-import static org.docopt.Python.split;
+import org.docopt.Pattern.MatchResult;
+import org.docopt.Python.*;
 
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.Set;
+import java.util.*;
 
-import org.docopt.Pattern.MatchResult;
-import org.docopt.Python.Re;
+import static org.docopt.Python.*;
 
 /**
  * Pythonic command-line interface parser that will make you smile.
@@ -95,18 +82,18 @@ public final class Docopt {
 		}
 
 		if (similar.size() > 1) {
-			List<String> _;
+			List<String> u;
 
 			// >>> o.long for o in similar
 			{
-				_ = list();
+				u = list();
 				for (final Option o : similar) {
-					_.add(o.getLong());
+					u.add(o.getLong());
 				}
 			}
 
 			throw tokens.error("%s is not a unique prefix: %s?", $long,
-					join(", ", _));
+					join(", ", u));
 		}
 
 		Option o;
@@ -129,9 +116,9 @@ public final class Docopt {
 			// >>> o = Option(similar[0].short, similar[0].long,
 			// >>> similar[0].argcount, similar[0].value)
 			{
-				final Option _ = similar.get(0);
-				o = new Option(_.getShort(), _.getLong(), _.getArgCount(),
-						_.getValue());
+				final Option u = similar.get(0);
+				o = new Option(u.getShort(), u.getLong(), u.getArgCount(),
+						u.getValue());
 			}
 
 			if (o.getArgCount() == 0) {
@@ -144,8 +131,8 @@ public final class Docopt {
 				if (value == null) {
 					// >>> if tokens.current() in [None, '--']
 					{
-						final String _ = tokens.current();
-						if (_ == null || "--".equals(_)) {
+						final String u = tokens.current();
+						if (u == null || "--".equals(u)) {
 							throw tokens.error("%s requires argument",
 									o.getLong());
 						}
@@ -212,9 +199,9 @@ public final class Docopt {
 				// >>> o = Option(short, similar[0].long,
 				// >>> similar[0].argcount, similar[0].value)
 				{
-					final Option _ = similar.get(0);
-					o = new Option($short, _.getLong(), _.getArgCount(),
-							_.getValue());
+					final Option u = similar.get(0);
+					o = new Option($short, u.getLong(), u.getArgCount(),
+							u.getValue());
 				}
 
 				String value = null;
@@ -223,8 +210,8 @@ public final class Docopt {
 					if ("".equals(left)) {
 						// >>> if tokens.current() in [None, '--']
 						{
-							final String _ = tokens.current();
-							if (_ == null || "--".equals(_)) {
+							final String u = tokens.current();
+							if (u == null || "--".equals(u)) {
 								throw tokens.error("%s requires argument",
 										$short);
 							}
@@ -325,15 +312,15 @@ public final class Docopt {
 			// Optional]}[token]
 			// >>> result = pattern(*parse_expr(tokens, options))
 			{
-				final List<? extends Pattern> _ = parseExpr(tokens, options);
+				final List<? extends Pattern> u = parseExpr(tokens, options);
 
 				if ("(".equals(token)) {
 					matching = ")";
-					result = list((Pattern) new Required(_));
+					result = list((Pattern) new Required(u));
 				}
 				else if ("[".equals(token)) {
 					matching = "]";
-					result = list((Pattern) new Optional(_));
+					result = list((Pattern) new Optional(u));
 				}
 				else {
 					throw new IllegalStateException();
@@ -423,10 +410,10 @@ public final class Docopt {
 		final List<Option> defaults = list();
 
 		for (String s : parseSection("options:", doc)) {
-			// >>> _, _, s = s.partition(':') # get rid of "options:"
+			// >>> u, u, s = s.partition(':') # get rid of "options:"
 			{
-				final String[] _ = partition(s, ":");
-				s = _[2];
+				final String[] u = partition(s, ":");
+				s = u[2];
 			}
 
 			List<String> split;
@@ -439,13 +426,13 @@ public final class Docopt {
 
 			// >>> split = [s1 + s2 for s1, s2 in zip(split[::2], split[1::2])];
 			{
-				final List<String> _ = list();
+				final List<String> u = list();
 
 				for (int i = 1; i < split.size(); i += 2) {
-					_.add(split.get(i - 1) + split.get(i));
+					u.add(split.get(i - 1) + split.get(i));
 				}
 
-				split = _;
+				split = u;
 			}
 
 			// >>> options = [Option.parse(s) for s in split if
@@ -467,23 +454,23 @@ public final class Docopt {
 			final String source) {
 		// >>> return [s.strip() for s in pattern.findall(source)]
 		{
-			final List<String> _ = Re.findAll("^([^\\n]*" + name +
+			final List<String> u = Re.findAll("^([^\\n]*" + name +
 					"[^\\n]*\\n?(?:[ \\t].*?(?:\\n|$))*)", source,
 					Re.IGNORECASE | Re.MULTILINE);
 
-			for (int i = 0; i < _.size(); i++) {
-				_.set(i, _.get(i).trim());
+			for (int i = 0; i < u.size(); i++) {
+				u.set(i, u.get(i).trim());
 			}
 
-			return _;
+			return u;
 		}
 	}
 
 	private static String formalUsage(String section) {
-		// >>> _, _, section = section.partition(':')
+		// >>> u, u, section = section.partition(':')
 		{
-			final String[] _ = partition(section, ":");
-			section = _[2];
+			final String[] u = partition(section, ":");
+			section = u[2];
 		}
 
 		final List<String> pu = split(section);
@@ -495,11 +482,11 @@ public final class Docopt {
 
 			sb.append("( ");
 
-			final String _ = pu.remove(0);
+			final String u = pu.remove(0);
 
 			if (!pu.isEmpty()) {
 				for (final String s : pu) {
-					if (s.equals(_)) {
+					if (s.equals(u)) {
 						sb.append(") | (");
 					}
 					else {
@@ -520,18 +507,18 @@ public final class Docopt {
 
 	private static void extras(final boolean help, final String version,
 			final List<? extends LeafPattern> options, final String doc) {
-		boolean _;
+		boolean u;
 
 		// >>> if help and any((o.name in ('-h', '--help')) and o.value for o in
 		// options)
 		{
-			_ = false;
+			u = false;
 
 			if (help) {
 				for (final LeafPattern o : options) {
 					if ("-h".equals(o.getName()) | "--help".equals(o.getName())) {
 						if (bool(o.getValue())) {
-							_ = true;
+							u = true;
 							break;
 						}
 					}
@@ -539,7 +526,7 @@ public final class Docopt {
 			}
 		}
 
-		if (_) {
+		if (u) {
 			throw new DocoptExitException(0, doc.replaceAll("^\\n+|\\n+$", ""),
 					false);
 		}
@@ -547,19 +534,19 @@ public final class Docopt {
 		// >>> if version and any(o.name == '--version' and o.value for o in
 		// options)
 		{
-			_ = false;
+			u = false;
 
 			if (bool(version)) {
 				for (final LeafPattern o : options) {
 					if ("--version".equals(o.getName())) {
-						_ = true;
+						u = true;
 						break;
 					}
 				}
 			}
 		}
 
-		if (_) {
+		if (u) {
 			throw new DocoptExitException(0, version, false);
 		}
 	}
@@ -696,12 +683,12 @@ public final class Docopt {
 			// >>> options_shortcut.children = list(set(doc_options) -
 			// pattern_options)
 			{
-				final List<Pattern> _ = ((BranchPattern) optionsShortcut)
+				final List<Pattern> u = ((BranchPattern) optionsShortcut)
 						.getChildren();
-				_.clear();
-				_.addAll(set(options));
+				u.clear();
+				u.addAll(set(options));
 				Pattern o = null;
-				for (final Iterator<Pattern> i = _.iterator(); i.hasNext();) {
+				for (final Iterator<Pattern> i = u.iterator(); i.hasNext();) {
 					o = i.next();
 					for (final Pattern x : patternOptions) {
 						if (o.equals(x)) {
@@ -719,7 +706,7 @@ public final class Docopt {
 		if (m.matched() && m.getLeft().isEmpty()) {
 			// >>> return Dict((a.name, a.value) for a in (pattern.flat() +
 			// collected))
-			final Map<String, Object> _ = new HashMap<String, Object>();
+			final Map<String, Object> u = new HashMap<String, Object>();
 
 			for (final Pattern p : pattern.flat()) {
 				// TODO: Does flat always return LeafPattern objects?
@@ -729,14 +716,14 @@ public final class Docopt {
 
 				final LeafPattern lp = (LeafPattern) p;
 
-				_.put(lp.getName(), lp.getValue());
+				u.put(lp.getName(), lp.getValue());
 			}
 
 			for (final LeafPattern p : m.getCollected()) {
-				_.put(p.getName(), p.getValue());
+				u.put(p.getName(), p.getValue());
 			}
 
-			return _;
+			return u;
 		}
 
 		throw new DocoptExitException(1, null, true);

--- a/src/main/java/org/docopt/Optional.java
+++ b/src/main/java/org/docopt/Optional.java
@@ -1,8 +1,8 @@
 package org.docopt;
 
-import static org.docopt.Python.list;
-
 import java.util.List;
+
+import static org.docopt.Python.list;
 
 class Optional extends BranchPattern {
 
@@ -18,9 +18,9 @@ class Optional extends BranchPattern {
 		}
 
 		for (final Pattern pattern : getChildren()) {
-			final MatchResult _ = pattern.match(left, collected);
-			left = _.getLeft();
-			collected = _.getCollected();
+			final MatchResult u = pattern.match(left, collected);
+			left = u.getLeft();
+			collected = u.getCollected();
 		}
 
 		return new MatchResult(true, left, collected);

--- a/src/test/java/org/docopt/DocoptTest.java
+++ b/src/test/java/org/docopt/DocoptTest.java
@@ -1,7 +1,10 @@
 package org.docopt;
 
-import static org.docopt.Python.list;
-import static org.docopt.Python.partition;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -13,12 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.docopt.Python.list;
+import static org.docopt.Python.partition;
 
 public final class DocoptTest extends TestCase {
 
@@ -139,11 +138,11 @@ public final class DocoptTest extends TestCase {
 			final String doc;
 			final String body;
 
-			// >>> doc, _, body = fixture.partition('"""')
+			// >>> doc, u, body = fixture.partition('"""')
 			{
-				final String[] _ = partition(fixture, "\"\"\"");
-				doc = _[0];
-				body = _[2];
+				final String[] u = partition(fixture, "\"\"\"");
+				doc = u[0];
+				body = u[2];
 			}
 
 			boolean first = true;
@@ -157,11 +156,11 @@ public final class DocoptTest extends TestCase {
 				final String argv;
 				final String expect;
 
-				// >>> argv, _, expect = case.strip().partition('\n')
+				// >>> argv, u, expect = case.strip().partition('\n')
 				{
-					final String[] _ = partition(_case.trim(), "\n");
-					argv = _[0];
-					expect = _[2];
+					final String[] u = partition(_case.trim(), "\n");
+					argv = u[0];
+					expect = u[2];
 				}
 
 				suite.addTest(new DocoptTest(String.format("%s_%d", name,
@@ -183,9 +182,9 @@ public final class DocoptTest extends TestCase {
 	}
 
 	private static List<String> argv(final String argv) {
-		final List<String> _ = list(argv.trim().split("\\s+"));
-		_.remove(0);
-		return _;
+		final List<String> u = list(argv.trim().split("\\s+"));
+		u.remove(0);
+		return u;
 	}
 
 	private static String argv(final List<String> argv) {


### PR DESCRIPTION
Compiling with JDK 8 reported:

```
warning: '_' used as an identifier
(use of '_' as an identifier might not be supported in releases after Java SE 8)
```

See [this thread](http://openjdk.5641.n7.nabble.com/Warning-about-single-underscore-identifier-td145974.html) for more info.

Also optimized the import statements.
