### PR TITLE
Fix #2 avoid java.lang.IllegalStateException in doParse.

### DIFF
--- a/src/main/java/org/docopt/Docopt.java
+++ b/src/main/java/org/docopt/Docopt.java
@@ -706,6 +706,8 @@ public final class Docopt {
 					for (final Pattern x : patternOptions) {
 						if (o.equals(x)) {
 							i.remove();
+							// Make sure we don't try to remove the same option twice
+							break;
 						}
 					}
 				}
@@ -787,3 +789,4 @@ public final class Docopt {
 		return this;
 	}
 }
+


### PR DESCRIPTION
As per the JavaDoc, you can only call remove() on an Iterator once per next(). Calling it a second time causes an illegal state exception.
