### PR TITLE
Updated pom.xml so the source jar gets installed or deployed to the maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.docopt</groupId>
   <artifactId>docopt</artifactId>
-  <version>0.6.0-SNAPSHOT</version>
+  <version>0.6.0-relaxed</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,28 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
+	<maven-source-plugin.version>2.4</maven-source-plugin.version>
 	<jackson.version>[2.0,)</jackson.version>
   </properties>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>${maven-source-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>

--- a/src/main/java/org/docopt/Argument.java
+++ b/src/main/java/org/docopt/Argument.java
@@ -2,7 +2,7 @@ package org.docopt;
 
 import java.util.List;
 
-class Argument extends LeafPattern {
+public class Argument extends LeafPattern {
 
 	public Argument(final String name, final Object value) {
 		super(name, value);

--- a/src/main/java/org/docopt/Command.java
+++ b/src/main/java/org/docopt/Command.java
@@ -2,7 +2,7 @@ package org.docopt;
 
 import java.util.List;
 
-final class Command extends Argument {
+public final class Command extends Argument {
 
 	public Command(final String name, final Object value) {
 		super(name, value);

--- a/src/main/java/org/docopt/Docopt.java
+++ b/src/main/java/org/docopt/Docopt.java
@@ -288,7 +288,7 @@ public final class Docopt {
 		return parsed;
 	}
 
-	private static Required parsePattern(final String source,
+	public static Required parsePattern(final String source,
 			final List<Option> options) {
 		final Tokens tokens = Tokens.fromPattern(source);
 		final List<? extends Pattern> result = parseExpr(tokens, options);
@@ -431,7 +431,7 @@ public final class Docopt {
 	 * argv ::= [ long | shorts | argument ]* [ '--' [ argument ]* ] ;
 	 * </pre>
 	 */
-	private static List<LeafPattern> parseArgv(final Tokens tokens,
+	public static List<LeafPattern> parseArgv(final Tokens tokens,
 			final List<Option> options, final boolean optionsFirst) {
 		final List<LeafPattern> parsed = list();
 

--- a/src/main/java/org/docopt/LeafPattern.java
+++ b/src/main/java/org/docopt/LeafPattern.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Leaf/terminal node of a pattern tree.
  */
-abstract class LeafPattern extends Pattern {
+public abstract class LeafPattern extends Pattern {
 
 	static class SingleMatchResult {
 

--- a/src/main/java/org/docopt/Option.java
+++ b/src/main/java/org/docopt/Option.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import org.docopt.Python.Re;
 
-final class Option extends LeafPattern {
+public final class Option extends LeafPattern {
 
 	private final String $short;
 

--- a/src/main/java/org/docopt/Pattern.java
+++ b/src/main/java/org/docopt/Pattern.java
@@ -8,9 +8,9 @@ import static org.docopt.Python.split;
 import java.util.Arrays;
 import java.util.List;
 
-abstract class Pattern {
+public abstract class Pattern {
 
-	static class MatchResult {
+	public static class MatchResult {
 
 		private final boolean match;
 
@@ -45,7 +45,7 @@ abstract class Pattern {
 
 	/**
 	 * Expand pattern into an (almost) equivalent one, but with single Either.
-	 * 
+	 *
 	 * Example: ((-a | -b) (-c | -d)) => (-a -c | -a -d | -b -c | -b -d) Quirks:
 	 * [-a] => (-a), (-a...) => (-a -a)
 	 */
@@ -203,7 +203,7 @@ abstract class Pattern {
 	protected abstract MatchResult match(List<LeafPattern> left,
 			List<LeafPattern> collected);
 
-	protected MatchResult match(final List<LeafPattern> left) {
+	public MatchResult match(final List<LeafPattern> left) {
 		return match(left, null);
 	}
 

--- a/src/main/java/org/docopt/Required.java
+++ b/src/main/java/org/docopt/Required.java
@@ -4,7 +4,7 @@ import static org.docopt.Python.list;
 
 import java.util.List;
 
-final class Required extends BranchPattern {
+public final class Required extends BranchPattern {
 
 	public Required(final List<? extends Pattern> children) {
 		super(children);

--- a/src/main/java/org/docopt/Tokens.java
+++ b/src/main/java/org/docopt/Tokens.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.docopt.Python.Re;
 
-final class Tokens extends ArrayList<String> {
+public final class Tokens extends ArrayList<String> {
 
 	private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
This change was provided so whenever the file: docopt-0.6.0-SNAPSHOT.jar gets installed or deployed, the file: docopt-0.6.0-SNAPSHOT-sources.jar goes along with it.

Doing this made it so I could create a new project which uses docopt.java, and maven would automatically pull down the sources and attach them to the libraries when I generated my eclipse project as follows:

> mvn eclipse:eclipse -DdownloadSources=true

I hope you find this change as useful as I did.
