### PR TITLE
add sections to pom.xml required for publishing to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,40 @@
   <artifactId>docopt</artifactId>
   <version>0.6.0-SNAPSHOT</version>
 
+  <name>docopt.java</name>
+  <url>https://github.com/docopt/docopt.java</url>
+  <description>Java port of docopt</description>
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+
+  <scm>
+    <connection>scm:git:git@github.com:docopt/docopt.java.git</connection>
+    <developerConnection>scm:git:git@github.com:docopt/docopt.java.git</developerConnection>
+    <url>https://github.com/docopt/docopt.java</url>
+  </scm>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Vladimir Keleshev</name>
+      <email>vladimir@keleshev.com</email>
+    </developer>
+    <developer>
+      <name>Damien Giese</name>
+      <email>damien.giese@gmail.com</email>
+    </developer>
+  </developers>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.6</maven.compiler.source>
@@ -36,4 +70,62 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>release</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.4</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+          
 </project>


### PR DESCRIPTION
In order to publish artifacts to Maven Central via the Sonatype OSSRH route, certain sections must be added to the pom. One is the OSSRH parent pom, which contains the adequate repositories to use. Another is a license section. Also, source and javadocs should also be uploaded so I've added those plugins as well.

The scm connection is required by the release plugin which is the recommended way for performing the releases.

Lastly, GPG signing is required for artifacts. Adding this to the normal project lifecycle would break most builds if gpg is not installed or configured. Instead, I've added this to a `release` profile, which also gets automatically activated by the `performRelease` property, which causes it to be automatically activated when using the `release` plugin.

I hope this helps expedite the process to get this officially into Central.
