### PR TITLE
Self-closing element in javadoc

### DIFF
--- a/src/main/java/org/docopt/Docopt.java
+++ b/src/main/java/org/docopt/Docopt.java
@@ -64,7 +64,7 @@ import org.docopt.Python.Re;
  *
  * Licensed under terms of MIT license (see LICENSE).
  * <p>
- * Copyright (c) 2012 Vladimir Keleshev, vladimir@keleshev.com<br />
+ * Copyright (c) 2012 Vladimir Keleshev, vladimir@keleshev.com<br>
  * Copyright (c) 2014 Damien Giese, damien.giese@gmail.com
  *
  * @version 0.6.0


### PR DESCRIPTION
Error occurs while generating javadoc because of a self-closing element (namely `<br />`).
Fix: changed `<br />` to`<br>`.
